### PR TITLE
잘못된 버전 표기 수정

### DIFF
--- a/xe/index.php
+++ b/xe/index.php
@@ -114,7 +114,7 @@
     <meta name="generator" content="XpressEngine (http://www.xpressengine.com)" />
     <meta http-equiv="imagetoolbar" content="no" />
 
-    <title>xe data export tool ver 0.4</title>
+    <title>xe data export tool ver 0.6</title>
     <style type="text/css">
         body { font-family:arial; font-size:9pt; }
         input.input_text { width:400px; }
@@ -140,7 +140,7 @@
 </head>
 <body>
 
-    <h1>xe data export tool ver 0.4</h1>
+    <h1>xe data export tool ver 0.6</h1>
 
     <?php
         if($errMsg) {


### PR DESCRIPTION
XE 마이그레이션 툴 버전이 0.6으로 업데이트 되었으나, 0.4로 표시하고 있는 표기 오류 수정